### PR TITLE
"fixed MinifyAll2OtherDocSelected for javascript and jsx"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ---
 
-## [Unreleased]
+## [**2.3.1**] - 2020-05-26
 
 ### Added
 
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 
 * Test: "Function \'getNewFilePath\' works" fixed to work on Windows.
+* Right click minify on the explorer working for JavaScript and JSX to close #48.
 
 ## [**2.3.0**] - 2020-05-18
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "minifyall",
 	"displayName": "MinifyAll",
 	"description": "Minifier for JSON, CSS, HTML, TWIG, LESS, SASS, SCSS, JavaScript, JSONC, and JavaScriptReact(testing). You will love its simplicity!",
-	"version": "2.3.0",
+	"version": "2.3.1",
 	"publisher": "josee9988",
 	"license": "SEE LICENSE IN LICENSE",
 	"author": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -242,8 +242,8 @@ export default function activate(context: vscode.ExtensionContext): void {
 							break;
 
 						case 'js': // JavaScript
-							if ((fileUri.path.split('.').pop() === 'javascript' && !settings.disableJavascript) ||
-								(fileUri.path.split('.').pop() === 'javascriptreact' && !settings.disableJavascriptReact)) {
+							if ((fileUri.path.split('.').pop() === 'js' && !settings.disableJavascript) ||
+								(fileUri.path.split('.').pop() === 'jsx' && !settings.disableJavascriptReact)) {
 								const path2NewFileJs: string = path.join(filePath, path.basename(fileUri.path).replace('.js', `${settings.prefix}.js`));
 								const minifierJs: any = Terser.minify(data);
 


### PR DESCRIPTION
#  MinifyAll2OtherDocSelected for minifying JS and JSX (v2.3.1)

## Summary

- Command "MinifyAll2OtherDocSelected", was expecting `.javascript` and `.javascriptreact` extensions, now changed to `.js` and `jsx` respectively.

close #48 