### PR TITLE
Configuration options `disableCodeContextMenu` and `disableFileExplorerContextMenu`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ---
 
+## [Unreleased]
+
+### Added
+
+* Configuration options `disableCodeContextMenu` and `disableFileExplorerContextMenu`, which allow the user to disable the respective contextmenus
+
 ## [**2.7.1**] - 2021-07-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -123,6 +123,18 @@ We recommend to use them with: "left click" on the document and then select the 
 "MinifyAll.disableMessages": true|false //default 'false' (by default it is allowed)
 ```
 
+- Disables context menu when right-clicking in your code.
+
+``` json
+"MinifyAll.disableCodeContextMenu": true|false //default 'false' (by default it is shown)
+```
+
+- Disables context menu when right-clicking in the file explorer.
+
+``` json
+"MinifyAll.disableFileExplorerContextMenu": true|false //default 'false' (by default it is shown)
+```
+
 - Minify on save (Default command, which will minify your actual code)
 
 ``` json

--- a/package.json
+++ b/package.json
@@ -203,6 +203,16 @@
 					"default": false,
 					"description": "If you want MinifyAll to stop showing error, warning or information messages. (True for disabling)"
 				},
+				"MinifyAll.disableCodeContextMenu": {
+					"type": "boolean",
+					"default": false,
+					"description": "If you want MinifyAll to not showing a context menu when right-clicking in the file explorer. (True for disabling)."
+				},
+				"MinifyAll.disableFileExplorerContextMenu": {
+					"type": "boolean",
+					"default": false,
+					"description": "If you want MinifyAll to not showing a context menu when right-clicking in the file explorer. (True for disabling).."
+				},
 				"MinifyAll.minifyOnSave": {
 					"type": "boolean",
 					"default": false,
@@ -258,26 +268,28 @@
 		"menus": {
 			"editor/context": [{
 					"command": "extension.MinifyAll",
-					"when": "editorLangId == html || editorLangId == css || editorLangId == scss || editorLangId == less || editorLangId == json || editorLangId == jsonc || editorLangId == javascript || editorLangId == javascriptreact",
+					"when": "!config.MinifyAll.disableCodeContextMenu && editorLangId in extension.supportedFiletypes",
 					"group": "MinifyAll"
 				},
 				{
 					"command": "extension.MinifyAll2OtherDoc",
-					"when": "editorLangId == html || editorLangId == css || editorLangId == scss || editorLangId == less || editorLangId == json || editorLangId == jsonc || editorLangId == javascript || editorLangId == javascriptreact",
+					"when": "!config.MinifyAll.disableCodeContextMenu && editorLangId in extension.supportedFiletypes",
 					"group": "MinifyAll"
 				},
 				{
 					"command": "extension.MinifyAllSelectedText",
-					"when": "editorLangId == html || editorLangId == css || editorLangId == scss || editorLangId == less || editorLangId == json || editorLangId == jsonc || editorLangId == javascript || editorLangId == javascriptreact || editorLangId == php",
+					"when": "!config.MinifyAll.disableCodeContextMenu && editorLangId in extension.supportedFiletypes || !config.MinifyAll.disableCodeContextMenu && editorLangId == php",
 					"group": "MinifyAll"
 				}
 			],
 			"explorer/context": [{
 					"command": "extension.MinifyAll2OtherDocSelected",
+					"when": "!config.MinifyAll.disableFileExplorerContextMenu",
 					"group": "MinifyAll"
 				},
 				{
 					"command": "extension.Compress",
+					"when": "!config.MinifyAll.disableFileExplorerContextMenu",
 					"group": "MinifyAll"
 				}
 			]

--- a/src/controller/getConfiguration.ts
+++ b/src/controller/getConfiguration.ts
@@ -91,6 +91,18 @@ export interface IUserSettings {
     disableMessages: boolean;
 
     /**
+     * disableCodeContextMenu: If you want MinifyAll to not showing a context
+     * menu when right-clicking in your code. (True for disabling).
+     */
+    disableCodeContextMenu: boolean;
+
+    /**
+     * disableFileExplorerContextMenu: If you want MinifyAll to not showing a
+     * context menu when right-clicking in the file explorer. (True for disabling).
+     */
+    disableFileExplorerContextMenu: boolean;
+
+    /**
      * minifyOnSave: If you want MinifyAll to minify every time you save in
      * the same file. (True for enabling).
      */
@@ -150,6 +162,8 @@ export function getUserSettings(): IUserSettings {
         disableJsonc: conf.get('disableJsonc'),
         disablePhp: conf.get('disablePhp'),
         disableMessages: conf.get('disableMessages'),
+        disableCodeContextMenu: conf.get('disableCodeContextMenu'),
+        disableFileExplorerContextMenu: conf.get('disableFileExplorerContextMenu'),
         minifyOnSave: conf.get('minifyOnSave'),
         minifyOnSaveToNewFile: conf.get('minifyOnSaveToNewFile') ? true : conf.get('minifyOnSaveToNewFIle'),
         PrefixOfNewMinifiedFiles: conf.get('PrefixOfNewMinifiedFiles'),

--- a/src/main.ts
+++ b/src/main.ts
@@ -65,6 +65,11 @@ const minifyHex: boolean = !settings.hexDisabled ? true : false;
 
 const globalMinifiers: MinifyAllClass = new MinifyAllClass(minifyHex);
 
+// List of suported Filetypes, can be used in package.json Context
+vscode.commands.executeCommand('setContext', 'extension.supportedFiletypes', [
+	'html', 'css', 'scss', 'less', 'json', 'jsonc', 'javascript', 'javascriptreact'
+]);
+
 /**
  * Summary main method that is executed when the extension is activated,
  * the extension is activated the very first time the command is executed,


### PR DESCRIPTION
# **Configuration options `disableCodeContextMenu` and `disableFileExplorerContextMenu`, which allow the user to disable the respective contextmenus**

This PR implements the feature requested in #120 

## **Description**

Two new options have been added:  `disableCodeContextMenu` and `disableFileExplorerContextMenu`. They can be used to disable the respective contextmenues.

They are evaluated inside the package.json inside the contextmenues *when* statements. The statmens where also shortend to ease reading and reduce redundentcy.


### **Additional context**

brackates are not posible inside *when* statments at the moment. See https://github.com/microsoft/vscode/issues/91473 for more information.

If brackates are implemented, the logic can be further simplefied.
