### PR TITLE
fixed wrong description for disableCodeContextMenu

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
 				"MinifyAll.disableCodeContextMenu": {
 					"type": "boolean",
 					"default": false,
-					"description": "If you want MinifyAll to not showing a context menu when right-clicking in the file explorer. (True for disabling)."
+					"description": "If you want MinifyAll to not showing a context menu when right-clicking in your code. (True for disabling)."
 				},
 				"MinifyAll.disableFileExplorerContextMenu": {
 					"type": "boolean",

--- a/src/main.ts
+++ b/src/main.ts
@@ -65,7 +65,7 @@ const minifyHex: boolean = !settings.hexDisabled ? true : false;
 
 const globalMinifiers: MinifyAllClass = new MinifyAllClass(minifyHex);
 
-// List of suported Filetypes, can be used in package.json Context
+// List of supported filetypes, can be used in package.json Context
 vscode.commands.executeCommand('setContext', 'extension.supportedFiletypes', [
 	'html', 'xml', 'php', 'twig', 'css', 'scss', 'less', 'json', 'jsonc', 'javascript', 'javascriptreact',
 ]);


### PR DESCRIPTION
# fixed wrong description for `disableCodeContextMenu`

extends #121 

## **Description**

A copy/pasting error happend in the description of the new option `disableCodeContextMenu`. It had a wrong description.

Also fixed a typo.
