### PR TITLE
added option to disable XML compression

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "minifyall",
 	"displayName": "MinifyAll",
-	"description": "Minifier for JSON, CSS, HTML, TWIG, LESS, SASS, SCSS, JavaScript, JSONC, and JavaScriptReact(testing). Compressor of files and folders. You will love its simplicity!",
+	"description": "Minifier for JSON, CSS, HTML, XML, TWIG, LESS, SASS, SCSS, JavaScript, JSONC, and JavaScriptReact(testing). Compressor of files and folders. You will love its simplicity!",
 	"version": "2.9.2",
 	"publisher": "josee9988",
 	"license": "SEE LICENSE IN LICENSE",
@@ -199,6 +199,11 @@
 					"type": "boolean",
 					"default": false,
 					"description": "If you want MinifyAll to stop minimizing PHP. (True for disabling)"
+				},
+				"MinifyAll.disableXml": {
+					"type": "boolean",
+					"default": false,
+					"description": "If you want MinifyAll to stop minimizing XML. (True for disabling)"
 				},
 				"MinifyAll.disableMessages": {
 					"type": "boolean",

--- a/package.json
+++ b/package.json
@@ -32,13 +32,12 @@
 		"Programming Languages"
 	],
 	"keywords": [
+		"minify",
 		"minifier",
 		"formatter",
 		"format",
 		"compressor",
 		"compress",
-		"minify",
-		"minifier",
 		"css",
 		"json",
 		"jsonc",

--- a/src/controller/checkLanguage.ts
+++ b/src/controller/checkLanguage.ts
@@ -63,7 +63,9 @@ export function checkLanguageJson(languageId: string, settings: IUserSettings): 
 export function checkLanguageHtmlPhp(languageId: string, settings: IUserSettings): boolean {
     if ((languageId === 'html' && !settings.disableHtml) ||
         (languageId === 'twig' && !settings.disableTwig) ||
-        ((languageId === 'php') && !settings.disablePhp) || languageId === 'vue' || languageId === 'vue-html' || languageId === 'xml') {
+        (languageId === 'php' && !settings.disablePhp) ||
+        (languageId === 'xml' && !settings.disableXml) ||
+        languageId === 'vue' || languageId === 'vue-html') {
         return true;
     }
     return false;

--- a/src/controller/getConfiguration.ts
+++ b/src/controller/getConfiguration.ts
@@ -91,6 +91,12 @@ export interface IUserSettings {
     disableMessages: boolean;
 
     /**
+     * disableXml: If you want MinifyAll to stop
+     * minimizing XML. (True for disabling).
+     */
+    disableXml: boolean;
+
+    /**
      * disableCodeContextMenu: If you want MinifyAll to not showing a context
      * menu when right-clicking in your code. (True for disabling).
      */
@@ -161,6 +167,7 @@ export function getUserSettings(): IUserSettings {
         disableJson: conf.get('disableJson'),
         disableJsonc: conf.get('disableJsonc'),
         disablePhp: conf.get('disablePhp'),
+        disableXml: conf.get('disableXml'),
         disableMessages: conf.get('disableMessages'),
         disableCodeContextMenu: conf.get('disableCodeContextMenu'),
         disableFileExplorerContextMenu: conf.get('disableFileExplorerContextMenu'),


### PR DESCRIPTION
# **added option to disable XML compression**

This PR fixes #129 


## **Description**

XML compression was added in V2.9.0  
This PR adds the option to disable XML compression.  
A boolean has been added to the settings that is checked every time the compresson of a xml file is requested.
