### PR TITLE
typos and spelling unifications

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -58,11 +58,7 @@ Instances of abusive, harassing or otherwise unacceptable behaviour may be
 reported by contacting the project team at jgracia9988@gmail.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
-<<<<<<< HEAD
-obligated to maintain confidentiality with regard to the reporter of an incident.
-=======
 obligated to maintain confidentiality concerning the reporter of an incident.
->>>>>>> template/master
 Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable MD024-->
 # **Change Log** 📜📝
 
-All notable changes to the "**MinifyAll**" VSCode extension will be documented in this file.
+All notable changes to the "**MinifyAll**" VS Code extension will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
@@ -29,7 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Fixed
 
-* Issue #125 (php context menu will only show to minify the selected text)
+* Issue #125 (PHP context menu will only show to minify the selected text)
 
 ## [**2.9.0**] - 2021-08-13
 
@@ -41,7 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Added
 
-* Configuration options `disableCodeContextMenu` and `disableFileExplorerContextMenu`, which allow the user to disable the respective contextmenus
+* Configuration options `disableCodeContextMenu` and `disableFileExplorerContextMenu`, which allow the user to disable the respective context menus
 
 ## [**2.7.1**] - 2021-07-18
 
@@ -65,7 +65,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Added
 
-* Compress command. It will be called from the menu and it is able to minify files or folders.
+* Compress command. It will be called from the menu, and it is able to minify files or folders.
 
 ### Changed
 
@@ -83,7 +83,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Added
 
 * List of posts in which the extension has been mentioned or reviewed.
-* 'tsc' as a default VSCode build task.
+* 'tsc' as a default VS Code build task.
 
 ### Changed
 
@@ -91,18 +91,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Removed
 
-* VSCode default watch task.
+* VS Code default watch task.
 
 ### Removed
 
-* Readme known bugs 'The command "Minify the selected document and preserve the original will not work on Windows'.
+* README known bugs 'The command "Minify the selected document and preserve the original" will not work on Windows'.
 
 ## [**2.5.18**] - 2021-04-11
 
 ### Fixed
 
 * Launch scripts and 'webpack' rules.
-* MinifyAll2OtherDoc 'scss' prefix of file fixed.
+* MinifyAll2OtherDoc 'SCSS' prefix of file fixed.
 
 ## [**2.5.16**] - 2021-04-11
 
@@ -114,7 +114,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Added
 
-* Recommended project build with webpack from vscode docs.
+* Recommended project build with webpack from VS Code docs.
 
 ## [**2.5.13**] - 2021-04-11
 
@@ -130,7 +130,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Added
 
-* If the output error 'We can not format this file type yet' occurs, it will tell the file type so it will be easier to understand.
+* If the output error 'We can not format this file type yet' occurs, it will tell the file type, so it will be easier to understand.
 
 ## [**2.5.11**] - 2021-04-06
 
@@ -179,26 +179,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Changed
 
-* Updated minifyall core version to 1.1.10.
+* Updated MinifyAll core version to 1.1.10.
 
 ### Removed
 
-* All CHANGELOGS from version 0.x to 1.x to not make this file that huge.
+* All CHANGELOGs from version 0.x to 1.x to not make this file that huge.
 * .map files to make the bundle size of the extension smaller.
 
 ## [**2.5.1**] - 2021-02-23
 
 ### Changed
 
-* Updated minifyall dependencies.
+* Updated MinifyAll dependencies.
 
 ## [**2.5.0**] - 2021-02-02
 
 ### Added
 
-* Package json scripts to publish the extension to VSX and vscode marketplace.
+* Package json scripts to publish the extension to VSX and VS Code marketplace.
 * Setting "terserMinifyOptions" will allow the users to fully customize their Terser options.
-* Updated the readme to announce the new setting.
+* Updated the README to announce the new setting.
 
 ### Removed
 
@@ -214,7 +214,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Removed
 
-* Bin folder from the vscode extension files.
+* Bin folder from the VS Code extension files.
 
 ## [**2.4.12**] - 2020-12-08
 
@@ -224,19 +224,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Removed
 
-* Errors showing in the VSCode extension profiler due to the missing .maps.
+* Errors showing in the VS Code extension profiler due to the missing .maps.
 
 ## [**2.4.11**] - 2020-12-08
 
 ### Added
 
-* Added the .map files again to the vscode repository (removed "**/*.map" from the .vscodeignore file).
+* Added the .map files again to the VS Code repository (removed "**/*.map" from the .vscodeignore file).
 
 ## [**2.4.10**] - 2020-12-03
 
 ### Added
 
-* Specific activation events to improve the VSCode startup time (MinifyAll will only be initialized when the user opens any of the supported file types). Close issue #72
+* Specific activation events to improve the VS Code startup time (MinifyAll will only be initialized when the user opens any of the supported file types). Close issue #72
 * Line in the README.md file asking for contributors.
 
 ## [**2.4.9**] - 2020-09-22
@@ -249,7 +249,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Added
 
-* Github issue templates from [josee's project-template](https://github.com/Josee9988/project-template).
+* GitHub issue templates from [josee's project-template](https://github.com/Josee9988/project-template).
 
 ## [**2.4.7**] - 2020-09-21
 
@@ -320,7 +320,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Fixed
 
-* Fixed multiple JSON problems by updating the MinifyAllCLi to 1.1.5.
+* Fixed multiple JSON problems by updating the MinifyAllCli to 1.1.5.
 
 ## [**2.3.1**] - 2020-05-26
 
@@ -337,7 +337,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Changed
 
-* From github workflow badge to png to solve vsce problem.
+* From GitHub workflow badge to PNG to solve vsce problem.
 
 ## [**2.3.0**] - 2020-05-18
 
@@ -354,7 +354,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Added
 
-* Link in the readme.md file to the new Minifyall cli package.
+* Link in the readme.md file to the new MinifyAllCli package.
 
 ## [**2.2.3**] - 2020-04-10
 
@@ -398,7 +398,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Fixed
 
-* Fixed problem with CSS minification (HTTPS URLS).
+* Fixed problem with CSS minification (HTTPS URLs).
 
 ## [**2.1.4**] - 2020-02-14
 
@@ -410,7 +410,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Fixed
 
-* Bug that changed '0%' into -> '0' in the css files.
+* Bug that changed '0%' into -> '0' in the CSS files.
 
 ## [**2.1.2**] - 2020-01-27
 
@@ -432,7 +432,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Fixed
 
-* Some variable names that weren't following the tslint rules at the main.ts file.
+* Some variable names that weren't following the TSLint rules at the main.ts file.
 
 ## [**2.0.3**] - 2019-12-30
 
@@ -472,7 +472,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 * Redundant code from showing messages in the main.ts file.
 * Useless code.
 * About 100 lines length in the main.ts file.
-* Useless tslint rules that were already extended from the recomended tslint options.
+* Useless TSLint rules that were already extended from the recommended TSLint options.
 
 ## [**2.0.1**] - 2019-12-26
 
@@ -489,11 +489,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Added
 
-* Extension recomendations in the .vscode/extension.json.
+* Extension recommendations in the .vscode/extension.json.
 * File showMessage.
 * Information in the controller's readme.md file about the new file showMessage.
 * Multiple changes to make the project use TypeScript.
-* File tsconfig and tslint to manage the TypeScript behaviour.
+* File tsconfig and TSLint to manage the TypeScript behaviour.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <!-- markdownlint-disable MD033-->
-# **MinifyAll an extension for VSCode**
+# **MinifyAll an extension for VS Code**
 
-Simple VSCode **minifier** and **compressor** for most common filetypes ([See full list below](#languages-available-)). You will love its simplicity!
+Simple VS Code **minifier** and **compressor** for most common file types ([See full list below](#languages-available-)). You will love its simplicity!
 
-You can minify the file and replace all the content with the new minified text, **or** you can preserve the original document and get the minified text in another document! Also, you can simply minify your **selected text**, you can preserve your license comments with the tags *@preserve* and *@endpreserve*.
+You can minify the file and replace all the content with the new minified text, **or** you can preserve the original document and get the minified text in another document! Also, you can simply minify your **selected text**, you can preserve your licence comments with the tags *@preserve* and *@endpreserve*.
 
 MinifyAll is also able to **compress** files and folders simply by right-clicking them on the menu.
 
@@ -11,12 +11,12 @@ Go to the extension *settings* and make it as you want, enable or disable: **min
 
 For more information check our: **[GitHub repository](https://github.com/Josee9988/MinifyAll)**, **[VisualStudio Marketplace](https://marketplace.visualstudio.com/items?itemName=josee9988.minifyall)** or **[OpenVSX registry](https://open-vsx.org/extension/Josee9988/minifyall)**.
 
-Also check the brand new **[MinifyAll online webpage](https://minifyall.jgracia.es/)** 😎 or the **[MinifyAll cli/package](https://github.com/Josee9988/MinifyAllCli)**.
+Also check the brand new **[MinifyAll online webpage](https://minifyall.jgracia.es/)** 😎 or the **[MinifyAllCli/package](https://github.com/Josee9988/MinifyAllCli)**.
 
 Do you want to help us improve the extension or did you found a bug?
 **[Let us know](https://github.com/Josee9988/MinifyAll/issues)**.
 
-Check our **[changelog](CHANGELOG.md)**.
+Check our **[CHANGELOG](CHANGELOG.md)**.
 
 Currently looking for active contributors to maintain and keep the project alive.
 
@@ -34,17 +34,17 @@ Currently looking for active contributors to maintain and keep the project alive
 
 ## **Installation** 🔩⚙
 
-- Open the **Command Palette** of VSCode with **Ctrl+P** or **⌘P**
+- Open the **Command Palette** of VS Code with **Ctrl+P** or **⌘P**
 - And type:➡️
 **```ext install josee9988.minifyall```**
 
 ### **Commands** 📐🛡
 
 - **```Minify this document ⚡``` Or ```CTRL+ALT+M```**
-- **```Minify this document and preserve the original ⛏```  Or ```CTRL+ALT+N```**
-- **```Minify the selected text 🎯```  Or ```CTRL+ALT+. CTRL+ALT+M```**
+- **```Minify this document and preserve the original ⛏``` Or ```CTRL+ALT+N```**
+- **```Minify the selected text 🎯``` Or ```CTRL+ALT+. CTRL+ALT+M```**
 
-We recommend to use them with: "left click" on the document and then select the option you want, either the file in the menu or the opened file. ;)
+We recommend using them with: "left click" on the document and then select the option you want, either the file in the menu or the opened file. ;)
 
 ---
 
@@ -54,7 +54,7 @@ We recommend to use them with: "left click" on the document and then select the 
 
 <img src="https://github.com/Josee9988/MinifyAll/blob/master/Screenshots/command.png?raw=true" alt="command" title="command"/>
 
-- Preserve your license comments with the tags *@preserve* (at the very top) and *@endpreserve*
+- Preserve your licence comments with the tags *@preserve* (at the very top) and *@endpreserve*
 
 <img src="https://github.com/Josee9988/MinifyAll/blob/master/Screenshots/Preserve.gif?raw=true" alt="preserve license" title="preserve license"/>
 
@@ -110,7 +110,7 @@ We recommend to use them with: "left click" on the document and then select the 
 <details>
 <summary>Click to see more info about the configuration settings</summary>
 
-(Remember to restart VSCode after modifying any configuration)
+(Remember to restart VS Code after modifying any configuration)
 
 - If you want MinifyAll to **stop shortening colours**, such as RGB to 3 digit hex, or RGBA to hex, or 6 digit hex to 3 digit hex. If you enable it you might see some loss in colour accuracy
 
@@ -160,7 +160,7 @@ We recommend to use them with: "left click" on the document and then select the 
 "MinifyAll.openMinifiedDocument": true|false //default 'true'
 ```
 
-- Terser minify options, this setting will allow you to fully customice your Terser behaviour. For more info please check [terser's minify options](https://github.com/terser/terser#minify-options).
+- Terser minify options, this setting will allow you to fully customize your Terser behaviour. For more info please check [terser's minify options](https://github.com/terser/terser#minify-options).
 
 ``` json
 "MinifyAll.terserMinifyOptions": { "mangle": true, "compress": { "drop_console": true, "dead_code": false, "keep_fnames": false, "keep_classnames": false } } // for more information please visit https://github.com/terser/terser#minify-options
@@ -168,55 +168,55 @@ We recommend to use them with: "left click" on the document and then select the 
 
 ### **Disabling languages configuration**
 
-- Disables **html** minimization
+- Disables **HTML** minimization
 
 ``` json
 "MinifyAll.disableHtml": true|false //default 'false' (by default it is enabled)
 ```
 
-- Disables **twig** minimization
+- Disables **TWIG** minimization
 
 ``` json
 "MinifyAll.disableTwig": true|false //default 'false' (by default it is enabled)
 ```
 
-- Disables **php** minimization
+- Disables **PHP** minimization
 
 ``` json
 "MinifyAll.disablePhp": true|false //default 'false' (by default it is enabled)
 ```
 
-- Disables **css** minimization
+- Disables **CSS** minimization
 
 ``` json
 "MinifyAll.disableCss": true|false //default 'false' (by default it is enabled)
 ```
 
-- Disables **scss** minimization
+- Disables **SCSS** minimization
 
 ``` json
 "MinifyAll.disableScss": true|false //default 'false' (by default it is enabled)
 ```
 
-- Disables **less** minimization
+- Disables **LESS** minimization
 
 ``` json
 "MinifyAll.disableLess": true|false //default 'false' (by default it is enabled)
 ```
 
-- Disables **sass** minimization
+- Disables **SASS** minimization
 
 ``` json
 "MinifyAll.disableSass": true|false //default 'false' (by default it is enabled)
 ```
 
-- Disables **json** minimization
+- Disables **JSON** minimization
 
 ``` json
 "MinifyAll.disableJson": true|false //default 'false' (by default it is enabled)
 ```
 
-- Disables **jsonc** minimization
+- Disables **JSONC** minimization
 
 ``` json
 "MinifyAll.disableJsonc": true|false //default 'false' (by default it is enabled)
@@ -246,7 +246,7 @@ We recommend to use them with: "left click" on the document and then select the 
 
 ## **Examples**
 
-### **Css less sass scss**
+### **CSS LESS SASS SCSS**
 
 <details>
 <summary>Click to see an example of how the extension minifies CSS</summary>
@@ -277,14 +277,14 @@ We recommend to use them with: "left click" on the document and then select the 
 - There are no spaces.
 - There is only one line.
 - Multiline comments removed.
-- Url '//' is not detected as a comment and can be perfectly placed.
+- URL '//' is not detected as a comment and can be perfectly placed.
 - From 0px to 0
 
 ---
 
 </details>
 
-### **Json jsonc**
+### **JSON JSON**
 
 <details>
 <summary>Click to see an example of how the extension minifies JSON</summary>
@@ -370,8 +370,8 @@ break;default:break;}}let myString="hello//";myString.replace(/\/\//g,'');
 - Spaces left are only within quotes (Strings) and variable declarations.
 - If 'OR' and 'AND' are without spaces, the same as if condition or switch cases.
 - All single line and multiline comments removed.
-- Single line comments inside of a String will not be removed. (hello//) (// not a comment).
-- Multi-line comments inside of a String will not be removed. (// not a comment **/\***).
+- Single line comments inside a String will not be removed. (hello//) (// not a comment).
+- Multi-line comments inside a String will not be removed. (// not a comment **/\***).
 - Regex expression with single-line comments will not be removed.
 - No tabs.
 
@@ -379,7 +379,7 @@ break;default:break;}}let myString="hello//";myString.replace(/\/\//g,'');
 
 </details>
 
-### **Html**
+### **HTML**
 
 <details>
 <summary>Click to see an example of how the extension minifies HTML</summary>
@@ -427,8 +427,8 @@ break;default:break;}}let myString="hello//";myString.replace(/\/\//g,'');
 
 ## **Known bugs:** 🛑🗑
 
-- ⚠️ If the file you are trying to minify is **not saved** or is an Untitled default VSCode file *might* cause errors.
-- ⚠️ If you are doing a regex without scaping the '//' it might be deleted as it must be escaped (\/\/).
+- ⚠️ If the file you are trying to minify is **not saved** or is an Untitled default VS Code file *might* cause errors.
+- ⚠️ If you are doing a regex without escaping the '//' it might be deleted as it must be escaped (\/\/).
 
 ---
 
@@ -440,19 +440,19 @@ Support the project and be the first donator ❤️
 
 ## 🎉 Did you enjoyed the minifier? Help us raise these numbers up
 
-[![Github followers](https://img.shields.io/github/followers/Josee9988.svg?style=social)](#did-you-enjoyed-the-minifier-help-us-raise-these-numbers-up--)
-[![Github stars](https://img.shields.io/github/stars/Josee9988/MinifyAll.svg?style=social)](#did-you-enjoyed-the-minifier-help-us-raise-these-numbers-up--)
-[![Github watchers](https://img.shields.io/github/watchers/Josee9988/MinifyAll.svg?style=social)](#did-you-enjoyed-the-minifier-help-us-raise-these-numbers-up--)
-[![Github forks](https://img.shields.io/github/forks/Josee9988/MinifyAll.svg?style=social)](#did-you-enjoyed-the-minifier-help-us-raise-these-numbers-up--)
+[![GitHub followers](https://img.shields.io/github/followers/Josee9988.svg?style=social)](#did-you-enjoyed-the-minifier-help-us-raise-these-numbers-up--)
+[![GitHub stars](https://img.shields.io/github/stars/Josee9988/MinifyAll.svg?style=social)](#did-you-enjoyed-the-minifier-help-us-raise-these-numbers-up--)
+[![GitHub watchers](https://img.shields.io/github/watchers/Josee9988/MinifyAll.svg?style=social)](#did-you-enjoyed-the-minifier-help-us-raise-these-numbers-up--)
+[![GitHub forks](https://img.shields.io/github/forks/Josee9988/MinifyAll.svg?style=social)](#did-you-enjoyed-the-minifier-help-us-raise-these-numbers-up--)
 [![Sponsor](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=github-sponsors&color=red&style=social)](https://github.com/sponsors/Josee9988)
 
-[Check my VSCode theme](https://marketplace.visualstudio.com/items?itemName=josee9988.black-garnet-theme) 🧲
+[Check my VS Code theme](https://marketplace.visualstudio.com/items?itemName=josee9988.black-garnet-theme) 🧲
 
-[Check my VSCode Markdown and Changelog snippets](https://marketplace.visualstudio.com/items?itemName=josee9988.changelog-and-markdown-snippets) 🌟
+[Check my VS Code Markdown and Changelog snippets](https://marketplace.visualstudio.com/items?itemName=josee9988.changelog-and-markdown-snippets) 🌟
 
 [Check my MinifyAll online webpage](https://minifyall.jgracia.es/) 😎
 
-[Check my MinifyAll cli/package](https://github.com/Josee9988/MinifyAllCli)
+[Check my MinifyAllCli/package](https://github.com/Josee9988/MinifyAllCli)
 
 ---
 
@@ -460,9 +460,9 @@ Support the project and be the first donator ❤️
 
 - [Minify Code Automatically](https://dev.to/aryaziai/minifying-code-shortcut-4d6c)
 - [How I made my website 10x faster](https://dev.to/asaoluelijah/how-i-made-my-personal-website-10x-faster-3p6k)
-- [11 plugins indispensables para VSCode](https://www.gitmedio.com/11-plugins-indispensables-para-visual-studio-code-insiders/)
-- [6 VSCode extensions you need to install now](https://it-it.facebook.com/AskHorizons/photos/a.128334975253236/386218132798251/?type=3&eid=ARDn_eorUZWvdCAV4C9taXZ5FFXu7Ib4e80xgui_LS-2y_m6VegoeCrc1JfFt6Bbyy7rXjEnPPSHCqTt)
-- [8 VSCode common extensions (chinnese)](https://www.leunghoyin.hk/vscode-common-extensions)
+- [11 plugins indispensables para VS Code](https://www.gitmedio.com/11-plugins-indispensables-para-visual-studio-code-insiders/)
+- [6 VS Code extensions you need to install now](https://it-it.facebook.com/AskHorizons/photos/a.128334975253236/386218132798251/?type=3&eid=ARDn_eorUZWvdCAV4C9taXZ5FFXu7Ib4e80xgui_LS-2y_m6VegoeCrc1JfFt6Bbyy7rXjEnPPSHCqTt)
+- [8 VS Code common extensions (Chinese)](https://www.leunghoyin.hk/vscode-common-extensions)
 
 ---
 

--- a/Screenshots/README.md
+++ b/Screenshots/README.md
@@ -1,5 +1,5 @@
 # **Screenshots**
 
-A folder with all the screenshots and gifs used in the **main README.md** file.
+A folder with all the screenshots and GIFs used in the **main README.md** file.
 
 It also includes the [icon.png](icon.png) which has been already been compressed.

--- a/src/controller/README.md
+++ b/src/controller/README.md
@@ -22,7 +22,7 @@ A Folder that contains some modules that are used by multiple languages, and it 
 
 ## **showMessage.js**
 
-**[showMessage](showMessage.js)** contains the functions to show messages from VSCode.
+**[showMessage](showMessage.js)** contains the functions to show messages from VS Code.
 
 ## **writeMinifiedCode.js**
 


### PR DESCRIPTION
# **typos and spelling unifications in READMEs and CHANGELOG**


## **Description**

I was spellchecking my additions to the changelog and my spellchecking plugin showed me some more errors, so I decided to fix them.

There are some real spelling errors, but most of it is unification of how exacly stuff is spelled.

I used british spellings, as that is what most people in europe learn.
